### PR TITLE
Customizes Blueprint combiner so that it uses the input protection domain

### DIFF
--- a/blueprint/blueprint-core/pom.xml
+++ b/blueprint/blueprint-core/pom.xml
@@ -32,7 +32,7 @@
     <artifactId>org.apache.aries.blueprint.core</artifactId>
     <packaging>bundle</packaging>
     <name>Apache Aries Blueprint Core</name>
-    <version>1.8.2</version>
+    <version>1.8.2_CODICE</version>
     <description>
         This bundle contains the core implementation of Blueprint
         along with the "ext" namespace handler.

--- a/blueprint/blueprint-core/src/main/java/org/apache/aries/blueprint/container/BlueprintDomainCombiner.java
+++ b/blueprint/blueprint-core/src/main/java/org/apache/aries/blueprint/container/BlueprintDomainCombiner.java
@@ -38,7 +38,7 @@ public class BlueprintDomainCombiner implements DomainCombiner {
 
     public ProtectionDomain[] combine(ProtectionDomain[] arg0,
                                       ProtectionDomain[] arg1) {
-        return new ProtectionDomain[] { new BlueprintProtectionDomain(bundleContext) };
+        return arg0;
     }
 
 }


### PR DESCRIPTION
This breaks standard sandbox security, relying on overall security of the system
instead.